### PR TITLE
Fix base URL to run correctly in local environment

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,5 +4,5 @@ import react from "@vitejs/plugin-react-swc"
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: "/music-app/",
+  base: process.env.GITHUB_ACTIONS ? "/music-app/" : "/",
 })


### PR DESCRIPTION
- GitHub Pagesにデプロイする時だけ、base URLが`/music-app/`でそれ以外では、`/`になるようにしました。GitHub Actionsでは`GITHUB_ACTIONS`というGitHub Actionsを使っている時には`true`となるような環境変数をデフォルトで用意しているので、それを使用しました。